### PR TITLE
Remove extra formatting for staticcheck

### DIFF
--- a/local_driver.go
+++ b/local_driver.go
@@ -205,7 +205,7 @@ func (d *LocalDriver) Remove(env dockerdriver.Env, removeRequest dockerdriver.Re
 	var vol *LocalVolumeInfo
 	var exists bool
 	if vol, exists = d.volumes[removeRequest.Name]; !exists {
-		logger.Error("failed-volume-removal", fmt.Errorf(fmt.Sprintf("Volume %s not found", removeRequest.Name)))
+		logger.Error("failed-volume-removal", fmt.Errorf("Volume %s not found", removeRequest.Name))
 		return dockerdriver.ErrorResponse{Err: fmt.Sprintf("Volume '%s' not found", removeRequest.Name)}
 	}
 


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
To fix an error: 
```
local_driver.go:208:41: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
```


Backward Compatibility
---------------
Breaking Change? **No**

